### PR TITLE
workaround for avoiding scroll-down command line.

### DIFF
--- a/autoload/ambicmd.vim
+++ b/autoload/ambicmd.vim
@@ -60,6 +60,7 @@ function! ambicmd#expand(key)
       if !cmdline
         let ret = (pumvisible() ? "\<C-y>" : '') . ret
       endif
+      redraw
       return ret
     endif
   endfor


### PR DESCRIPTION
`:perldoc`とタイプしてスペースを押すと、perldocの部分が残り

```
:perldoc
:Perldoc
```

となる事があります。最後の描画状態によりコマンド行を残すかどうかを決めている様なので、ワークアラウンドとしてredrawいれてみました。
一応綺麗に動いてます。
