### PR TITLE
Allow leading space

### DIFF
--- a/autoload/ambicmd.vim
+++ b/autoload/ambicmd.vim
@@ -43,7 +43,7 @@ function! ambicmd#expand(key)
   if line[pos] =~# '\S'
     return a:key
   endif
-  let cmd = matchstr(line[: pos], '^\s*\zs[^[:space:]]*')
+  let cmd = matchstr(line[: pos], '^\s*\zs\a[^[:space:]]*')
 
   let state = exists(':' . cmd)
   if cmd == '' || (cmd =~# '^\l' && state == 1) || state == 2


### PR DESCRIPTION
```
`:    perldoc select`
```

が

```
`:    Perldoc select`
```

になる様に
