### PR TITLE
Ignore / on visual mode

### DIFF
--- a/autoload/ambicmd.vim
+++ b/autoload/ambicmd.vim
@@ -32,7 +32,7 @@ let s:command_extractor = '\v^' . s:range . '\zs\a\w*!?$'
 
 " Expand ambiguous command.
 function! ambicmd#expand(key)
-  let cmdline = mode() ==# 'c'
+  let cmdline = index(['c', 'v', 'V', "\<c-v>"], mode()) != -1
   if cmdline && getcmdtype() != ':'
     return a:key
   endif


### PR DESCRIPTION
Visual select 時に

```
/^get<cr>
```

といった感じに検索すると

```
/^Get^D
```

に置き換わってしまうので無視する様にしました。
