### PR TITLE
Update the detecting of input of commands

### DIFF
--- a/autoload/ambicmd.vim
+++ b/autoload/ambicmd.vim
@@ -1,8 +1,9 @@
-" You can use ambiguous command.
+" You can use ambiguous commands.
 " Version: 0.5.1
 " Authors: thinca <thinca+vim@gmail.com>
 "          Shougo <Shougo.Matsu (at) gmail.com>
 "          tyru   <tyru.exe@gmail.com>
+"          mityu  <mityu.email (at) gmail.com>
 " License: zlib License
 
 if !exists('g:ambicmd#build_rule')
@@ -20,62 +21,54 @@ function! ambicmd#default_rule(cmd)
   \ ]
 endfunction
 
-let s:search_pattern = '\v/[^/]*\\@<!%(\\\\)*/|\?[^?]*\\@<!%(\\\\)*\?'
-let s:line_specifier =
-\   '\v%(\d+|[.$]|''\S|\\[/?&])?%([+-]\d*|' . s:search_pattern . ')*'
-let s:range = '\v%(\%|' . s:line_specifier .
-\              '%([;,]' . s:line_specifier . ')*)?'
-let s:command_extractor = '\v^' . s:range . '\zs\a\w*!?$'
+function! s:escape_for_very_magic(str) abort
+  return escape(a:str, '\.^$?*+~()[]{@|=&')
+endfunction
 
-" Expand ambiguous command.
-function! ambicmd#expand(key)
-  " 'v'/'V'/'<C-v>' are used used by a search by a visual mode.
-  let cmdline = index(['c', 'v', 'V', "\<C-v>"], mode()) != -1
-  if cmdline && getcmdtype() !=# ':'
-    return a:key
-  endif
-  let line =  cmdline ? getcmdline() : getline('.')
-  let pos  = (cmdline ? getcmdpos()  : col('.')) - 1
-  if line[pos] =~# '\S'
-    return a:key
-  endif
-  let cmdb = matchstr(line[: pos - 1], s:command_extractor)
-  let [cmd, bang] = matchlist(cmdb, '^\(.\{-}\)\(!\?\)$')[1 : 2]
+function! s:PATTERN_NON_ESCAPE_CHAR(char, ...) abort
+  let force_escape = exists('a:1') ? a:1 : 1
+  return '\v%(%(\_^|[^\\])%(\\\\)*)@<=' .
+  \   (force_escape ? s:escape_for_very_magic(a:char) : a:char)
+endfunction
 
-  let state = exists(':' . cmd)
-  if cmd ==# '' || (cmd =~# '^\l' && state == 1) || state == 2
-    return a:key
-  endif
+function! s:generate_range_matcher() abort
+  let range_factor_search = printf('%%(/.*%s|\?.*%s)',
+  \   s:PATTERN_NON_ESCAPE_CHAR('/'),
+  \   s:PATTERN_NON_ESCAPE_CHAR('?'))
+  let range_factors = [
+  \   '\d+',
+  \   '[.$%]',
+  \   "'.",
+  \   range_factor_search . '%(' . range_factor_search . ')?',
+  \   '\\[/?&]',
+  \ ]
+  let range_specifier = '%(' . join(range_factors, '|') .
+  \   ')%(\s*[+-]\d+)?'
+  return '\v' . range_specifier . '%(\s*[,;]\s*' .
+  \   range_specifier . ')?'
+endfunction
 
-  let cmdlist = s:get_cmd_list()
+let s:PATTERN_RANGE = s:generate_range_matcher()
+let s:PATTERN_NON_ESCAPE_WHITESPACE = s:PATTERN_NON_ESCAPE_CHAR('\s', 0)
+let s:PATTERN_NON_ESCAPE_BAR = s:PATTERN_NON_ESCAPE_CHAR('|')
+let s:PATTERN_SINGLE_QUOTE_PAIR = ["'", '\v%(%(\_^|[^''])%('''')*)@<=''([^'']|$)@=']
+let s:PATTERN_DOUBLE_QUOTE_PAIR = ['"', s:PATTERN_NON_ESCAPE_CHAR('"')]
 
-  let prekey = !cmdline && pumvisible() ? "\<C-y>" : ''
-  let filtered_lists = []
-  " Search matching.
-  for pat in call(g:ambicmd#build_rule, [cmd], {})
-    let filtered = filter(copy(cmdlist), 'v:val =~? pat')
-    call add(filtered_lists, filtered)
-    if len(filtered) == 1
-      let newcmd = filtered[0] . bang
-      return prekey . repeat("\<C-h>", strlen(cmdb)) . newcmd . a:key
-    endif
-  endfor
+" NOTE: Keys are evaluated under very magic.
+let s:TABLE_SPECIAL_CMDS = {
+\   'g%[lobal]': 'global',
+\   'v%[global]': 'global',
+\   'exe%[cute]': 'execute',
+\   }
 
-  " Expand the head of common part.
-  for filtered in filtered_lists
-    if empty(filtered)
-      continue
-    endif
-    let common = filtered[0]
-    for str in filtered[1 :]
-      let common = matchstr(common, '^\C\%[' . str . ']')
-    endfor
-    if len(cmd) <= len(common)
-      return prekey . repeat("\<C-h>", len(cmdb)) . common . "\<C-d>"
-    endif
-  endfor
 
-  return a:key
+function! s:has_item(list, item) abort
+  return index(a:list, a:item) != -1
+endfunction
+
+function! s:str_divide_pos(string, pos) abort
+  " NOTE: Use strpart() by considering a:pos == 0.
+  return [strpart(a:string, 0, a:pos), a:string[a:pos :]]
 endfunction
 
 function! s:get_cmd_list() abort
@@ -83,5 +76,233 @@ function! s:get_cmd_list() abort
   silent! command
   redir END
   return map(split(cmdlistredir, "\n")[1 :],
-  \          'matchstr(v:val, ''\u\w*'')')
+  \   'matchstr(v:val, ''\u\w*'')')
+endfunction
+
+function! s:get_cmdline_info() abort
+  let is_cmdline = s:has_item(['c', 'v', 'V', "\<C-v>"], mode())
+  if !is_cmdline
+    if exists('*getcmdwintype')
+      let cmdtype = getcmdwintype()
+      let is_cmdwin = (cmdtype !=# '')
+    else
+      if (bufname('%') ==# '[Command Line]') && (&l:filetype ==# 'vim') &&
+      \  (!&l:rightleft) && (&l:buftype ==# 'nofile') && (!&l:swapfile)
+        let is_cmdwin = 1
+        let cmdtype = ':'
+      else
+        let is_cmdwin = 0
+        let cmdtype = ''
+      endif
+    endif
+  else
+    let is_cmdwin = 0
+    let cmdtype = getcmdtype()
+  endif
+  return [is_cmdline, is_cmdwin, cmdtype]
+endfunction
+
+function! s:remove_range_specifier(cmdline) abort
+  return substitute(a:cmdline, '\v^\s*\zs' . s:PATTERN_RANGE, '', '')
+endfunction
+
+function! s:remove_head_whitespace(cmdline) abort
+  return substitute(a:cmdline, '^\s*', '', '')
+endfunction
+
+function! s:cancel_expanding() abort
+  throw 'ambicmd: CancelExpanding'
+endfunction
+
+function! s:get_identifier_if_special_cmd(cmdbase) abort
+  let cmdbase = matchstr(a:cmdbase, '^\s*\zs\w*') " Get command name
+  if cmdbase ==# ''
+    return ''
+  endif
+  for [key, identifier] in items(s:TABLE_SPECIAL_CMDS)
+    if cmdbase =~# '\v^' . key . '$'
+      return identifier
+    endif
+  endfor
+  return ''
+endfunction
+
+function! s:separate_cmd_bang(cmd) abort
+  if a:cmd[-1 :] ==# '!'
+    let bang = '!'
+    let target = a:cmd[: -2]
+  else
+    let bang = ''
+    let target = a:cmd
+  endif
+  return [target, bang]
+endfunction
+
+function! s:parse_cmd(cmdline) abort
+  let cmdline = a:cmdline
+  while 1
+    let cmdline = s:remove_range_specifier(cmdline)
+    if cmdline =~# '^\s*$'
+      call s:cancel_expanding()
+    endif
+    let identifier = s:get_identifier_if_special_cmd(cmdline)
+    if identifier !=# ''
+      return s:parse_cmd_{identifier}(s:remove_head_whitespace(cmdline))
+    endif
+
+    let index = match(cmdline, s:PATTERN_NON_ESCAPE_BAR)
+    if index == -1
+      break
+    endif
+    let cmdline = cmdline[index + 1 :]
+  endwhile
+
+  if cmdline =~# '^\s'
+    call s:cancel_expanding()
+  endif
+
+  let [target, bang] = s:separate_cmd_bang(cmdline)
+  if match(target, '\A') == -1
+    return [target, bang]
+  else
+    call s:cancel_expanding()
+  endif
+endfunction
+
+function! s:parse_cmd_global(cmdline) abort
+  let cmdargs = matchstr(a:cmdline,
+  \   '\v^%(g%[lobal]!?|v%[global])\s*\zs.*')
+  if cmdargs ==# ''
+    call s:cancel_expanding()
+  endif
+  let pattern_separator = s:PATTERN_NON_ESCAPE_CHAR(cmdargs[0])
+  let arg_command = matchstr(cmdargs,
+  \   '\v^' . pattern_separator . '.{-}' . pattern_separator . '\zs.*$')
+  if arg_command ==# ''
+    call s:cancel_expanding()
+  else
+    return s:parse_cmd(arg_command)
+  endif
+endfunction
+
+function! s:parse_cmd_execute(cmdline) abort
+  let cmdline = matchstr(a:cmdline,
+  \   '\v^exe%[cute]\s+\zs.*')
+  if cmdline ==# ''
+    call s:cancel_expanding()
+  endif
+  while 1
+    let pos = {}
+    let pos.single_quote = match(cmdline, "'")
+    let pos.double_quote = match(cmdline, '"')
+    let pos.bar = match(cmdline, s:PATTERN_NON_ESCAPE_BAR)
+
+    let closest = {'kind': '', 'pos': -1}
+    for [kind, match_pos] in items(pos)
+      if match_pos == -1
+        continue
+      elseif (closest.pos == -1) || (match_pos < closest.pos)
+        let closest.kind = kind
+        let closest.pos = match_pos
+      endif
+    endfor
+    if closest.pos == -1
+      call s:cancel_expanding()
+    endif
+    if closest.kind ==# 'bar'
+      let cmdline = cmdline[closest.pos + 1 :]
+      break
+    endif
+    let closest.kind = toupper(closest.kind)
+    let pos_pair = match(cmdline,
+    \   s:PATTERN_{closest.kind}_PAIR[1], closest.pos + 1)
+    if pos_pair == -1
+      let cmdline = cmdline[closest.pos :]
+
+      " Unescape single/double quotes.
+      let cmdline = eval(cmdline . s:PATTERN_{closest.kind}_PAIR[0])
+      break
+    else
+      let cmdline = cmdline[pos_pair + 1 :]
+    endif
+  endwhile
+
+  return s:parse_cmd(cmdline)
+endfunction
+
+function! s:get_completion(target) abort
+  if a:target ==# ''
+    call s:cancel_expanding()
+  endif
+  let cmdstate = exists(':' . a:target)
+  if (cmdstate == 2) || (a:target =~# '^\l' && cmdstate == 1)
+    call s:cancel_expanding()
+  endif
+
+  let commands = s:get_cmd_list()
+  let filtered_list = []
+
+  " Try to find the only completion.
+  for pattern in call(g:ambicmd#build_rule, [a:target])
+    let filtered = filter(copy(commands), 'v:val =~? pattern')
+    if len(filtered) == 1
+      return [filtered[0], 1]
+    endif
+    call add(filtered_list, filtered)
+  endfor
+
+  " Emulate "longest" function of 'wildmode'.
+  for filtered in filtered_list
+    if empty(filtered)
+      continue
+    endif
+    let common = filtered[0]
+    for completion in filtered[1 :]
+      let common = matchstr(common, '^\C\%[' . completion . ']')
+    endfor
+    if strlen(common) >= strlen(a:target)
+      return [common, 0]
+    endif
+  endfor
+
+  call s:cancel_expanding()
+endfunction
+
+function! ambicmd#expand(keys) abort
+  let [is_cmdline, is_cmdwin, cmdtype] = s:get_cmdline_info()
+  if (is_cmdline || is_cmdwin) && cmdtype !=# ':'
+    return a:keys
+  endif
+  let [cmdline, after_cursor] = s:str_divide_pos(
+  \   (is_cmdline ? getcmdline() : getline('.')),
+  \   (is_cmdline ? getcmdpos() : col('.')) - 1
+  \   )
+  if after_cursor =~# '^\w' || cmdline ==# ''
+    return a:keys
+  endif
+
+  try
+    let [target, bang] = s:parse_cmd(cmdline)
+    let [completion, is_fullmatch] = s:get_completion(target)
+  catch /^ambicmd\:\sCancelExpanding$/
+    return a:keys
+  endtry
+  if target ==# completion && is_fullmatch
+    return a:keys
+  endif
+
+  let prefix = (!is_cmdline && pumvisible()) ? "\<C-y>" : ''
+
+  if is_fullmatch
+    let suffix = a:keys
+  elseif is_cmdline
+    let suffix = "\<C-d>"
+  else
+    let suffix = ''
+  endif
+
+  if is_fullmatch
+    let completion .= bang
+  endif
+  return prefix . repeat("\<C-h>", strlen(target . bang)) . completion . suffix
 endfunction

--- a/doc/ambicmd.txt
+++ b/doc/ambicmd.txt
@@ -1,9 +1,10 @@
-*ambicmd.txt*	You can use ambiguous command.
+*ambicmd.txt*	You can use ambiguous commands.
 
 Version: 0.5.1
 Authors: thinca <thinca+vim@gmail.com>
          Shougo <Shougo.Matsu (at) gmail.com>
          tyru   <tyru.exe@gmail.com>
+         mityu  <mityu.email (at) gmail.com>
 License: zlib License
 
 ==============================================================================
@@ -23,29 +24,38 @@ CHANGELOG			|ambicmd-changelog|
 ==============================================================================
 INTRODUCTION					*ambicmd-introduction*
 
-*ambicmd* is a Vim plugin to use ambiguous command.
-Some plugins provide many useful command, but sometimes these are very long.
-At this time, you will define the key mappings to execute these. but:
+*ambicmd* is a Vim plugin to use ambiguous commands.
+Some plugins provide many useful commands, but sometimes these are very long.
+At this time, you will define the key mappings to execute these. However:
 
 - You will have to define quite a lot of key mappings.
-- You should find unused key sequence for mapping.
+- You should find unused key sequences for mapping.
 - Do you define a key mapping for a command only occasionally used?
 
-This plugin expands a ambiguous command by some patterns.  For example,
+This plugin expands ambiguous {command}s into user-defined commands by some
+patterns when they are at:
+
+- :{command}
+- :{some-commands}|{command}
+- :global/{pattern}/{command}
+- :execute "{command}"
+
+The following are examples of how this plugin expands ambiguous commands when
+you configure this: `:cnoremap <expr> <Space> ambicmd#expand("\<Space>")`
 >
 	("|" is cursor)
-	" Expands to the correct name from the lowercase.
+	" Expands into the correct name from the lowercase.
 	:ref<Space>  =>  :Ref |
 
-	" Expands from the capital letter of the command.
+	" Expands from the capital letters of the command.
 	:qr<Space>   =>  :QuickRun |
 
-	" There are some commands with "NeoComplCache" prefix.
+	" If there are some commands with "NeoComplCache" prefix, complete it.
 	:ncc<Space>  =>  :NeoComplCache|
 <
 See |ambicmd-expanding-rule| about the expanding rule.
-Note that you need write some setting in vimrc.  This plugin do nothing by
-default.  Please see |ambicmd-setting-examples|.
+Note that you need write some settings in your vimrc because this plugin does
+nothing by default.  Please see |ambicmd-setting-examples|.
 
 
 Requirements:
@@ -66,6 +76,9 @@ ambicmd#expand({key-sequence})			*ambicmd#expand()*
 	Expands the command.
 	- If the cursor position is not just behind a command, returns
 	  {key-sequence} directly.
+	- If the command has spaces on its head, returns {key-sequence}
+	  directly too.  (Therefore, you can avoid expanding by putting
+	  spaces.)
 	- If the expanding succeeded, returns the command and {key-sequence}.
 	- If the candidates of the command starts by the same phrase, returns
 	  it and <C-d>.
@@ -78,8 +91,9 @@ ambicmd#expand({key-sequence})			*ambicmd#expand()*
 CUSTOMIZING					*ambicmd-customizing*
 
 g:ambicmd#build_rule				*g:ambicmd#build_rule*
-	String of function name that returns the rule.  The function takes a
-	command as argument, and returns a list of pattern.
+	|String| of function name or |Funcref|.  The function takes an inuptted
+	command as argument, and have to return a list of patterns to filter
+	user-defined commands.
 	See |ambicmd-expanding-rule| for the details.
 	The default value is "ambicmd#default_rule".
 
@@ -88,9 +102,9 @@ g:ambicmd#build_rule				*g:ambicmd#build_rule*
 ==============================================================================
 EXPANDING RULE					*ambicmd-expanding-rule*
 
-The rule is a list of regexp pattern.  All of user-defined command is filtered
-by the first pattern.  The pattern matching is done with |=~?|.  If the
-command is narrowed to one, it expand to the command.  Otherwise, the next
+The rule is a list of |regexp| patterns.  All of user-defined commands are
+filtered by the first pattern.  The pattern matching is done with |=~?|.  If
+the command is narrowed to one, it expand to the command.  Otherwise, the next
 pattern is tried like same.
 When the rule can not decide the only command, searches from the non empty
 first result for a common first part.  It is expanded when it is found.
@@ -101,18 +115,21 @@ Otherwise, nothing is done.
 ==============================================================================
 SETTING EXAMPLES				*ambicmd-setting-examples*
 
-Expands ambiguous command with <Space> and <CR>.
+Expand ambiguous commands with <Space> and <CR>.
 >
 	cnoremap <expr> <Space> ambicmd#expand("\<Space>")
 	cnoremap <expr> <CR>    ambicmd#expand("\<CR>")
 <
-Mapping <C-f> to <Right> with ambicmd.
+Map <C-f> to <Right> with ambicmd.
 >
 	cnoremap <expr> <C-f> ambicmd#expand("\<Right>")
 >
 Use in |cmdline-window|.
 >
-	autocmd CmdwinEnter * call s:init_cmdwin()
+	augroup init_cmdwin
+	  autocmd!
+	  autocmd CmdwinEnter * call s:init_cmdwin()
+	augroup END
 	function! s:init_cmdwin()
 	  inoremap <buffer> <expr> <Space> ambicmd#expand("\<Space>")
 	  inoremap <buffer> <expr> <CR>    ambicmd#expand("\<CR>")
@@ -128,9 +145,7 @@ TODO						*ambicmd-todo*
 - Improves the expanding rule.
   - Any idea?
 
-- Improves the detecting of input of command.
-  - :g/pattern/Command
-  - But these is very hard...
+- Improves the detecting of input of commands.
   - If you want to avoid the expanding, please input it like <C-v><Space>.
 
 

--- a/test/ambicmd.vimspec
+++ b/test/ambicmd.vimspec
@@ -1,5 +1,223 @@
+let s:functions = themis#helper('scope').funcs('autoload/ambicmd.vim')
+call themis#func_alias(s:functions)
 call themis#helper('command').with(themis#helper('assert'))
 
+
+" NOTE: Don't use `:function!` in order not to overwrite.
+Describe s:str_divide_pos()
+  Before all
+    let StrDividePos = s:functions.str_divide_pos
+  End
+  It separates a string into two strings by position
+    let str = '0123456789'
+    Assert Equals(StrDividePos(str, 4), ['0123', '456789'])
+    Assert Equals(StrDividePos(str, 0), ['', '0123456789'])
+  End
+End
+Describe s:separate_cmd_bang()
+  Before all
+    function SeparateCmdBang(cmd)
+      return s:functions.separate_cmd_bang(a:cmd)
+    endfunction
+  End
+  It separates '!' if it's given
+    Assert Equals(SeparateCmdBang('cmd!'), ['cmd', '!'])
+  End
+  It does nothing if '!' isn't given
+    Assert Equals(SeparateCmdBang('cmd'), ['cmd', ''])
+  End
+  After all
+    delfunction SeparateCmdBang
+  End
+End
+Describe s:remove_range_specifier()
+  Before all
+    function RemoveRange(cmdline)
+      return s:functions.remove_range_specifier(a:cmdline)
+    endfunction
+  End
+  It removes range
+    let ranges = ['%', '$', '.', "'<,'>", '1,10', '1, 10', '4', '/hoge/',
+    \ '?fuga?', '\/', '\?', '\&']
+    let extensions = ['', '+3', '-1']
+    for range in ranges
+      for extension in extensions
+        let cmdline = range . extension . 'cmd'
+        Assert Equals(RemoveRange(cmdline), 'cmd')
+      endfor
+    endfor
+  End
+  It does nothing when range isn't provided
+    Assert Equals(RemoveRange('cmd'), 'cmd')
+  End
+  After all
+    delfunction RemoveRange
+  End
+End
+Describe s:parse_cmd()
+  Before all
+    function PickTarget(cmdline) abort
+      try
+        return s:functions.parse_cmd(a:cmdline)[0]
+      catch /^ambicmd\:\sCancelExpanding$/
+        return ''
+      endtry
+    endfunction
+  End
+  It picks the command
+    Assert Equals(PickTarget('cmd'), 'cmd')
+  End
+  It picks the command with '!'
+    Assert Equals(PickTarget('cmd!'), 'cmd')
+  End
+  It won't pick the command when inputting arguments
+    Assert Equals(PickTarget('cmd hoge'), '')
+  End
+  It doesn't allow leading spaces
+    Assert Equals(PickTarget(' cmd'), '')
+    Assert Equals(PickTarget('some_cmd| cmd'), '')
+    Assert Equals(PickTarget(' some_cmd|cmd'), 'cmd')
+    Assert Equals(PickTarget('% cmd'), '')
+    Assert Equals(PickTarget(' %cmd'), '')
+    Assert Equals(PickTarget(' some_cmd|% cmd'), '')
+    Assert Equals(PickTarget(' some_cmd| ''<,''>cmd'), '')
+    Assert Equals(PickTarget(' g/pat/ com'), '')
+    Assert Equals(PickTarget(' execute " com'), '')
+  End
+  It supports :global
+    Assert Equals(PickTarget('g/pat/cmd'), 'cmd')
+    Assert Equals(PickTarget('g/pat/cmd hoge'), '')
+    Assert Equals(PickTarget('g/pat/cmd'), 'cmd')
+  End
+  It supports :global!
+    Assert Equals(PickTarget('g!/pat/cmd'), 'cmd')
+    Assert Equals(PickTarget('g!/pat/cmd hoge'), '')
+    Assert Equals(PickTarget('g!/pat/cmd'), 'cmd')
+  End
+  It supports :vglobal
+    Assert Equals(PickTarget('v/pat/cmd'), 'cmd')
+    Assert Equals(PickTarget('v/pat/cmd hoge'), '')
+    Assert Equals(PickTarget('v/pat/cmd'), 'cmd')
+  End
+  It supports :global with its separator is not '/'
+    Assert Equals(PickTarget('g?pat?cmd'), 'cmd')
+  End
+  It supports :global with its separator is in {pattern} with escaped
+    Assert Equals(PickTarget('g/pat\/tern/cmd'), 'cmd')
+  End
+  It supports :global even if <bar> exists in {pattern}
+    Assert Equals(PickTarget('g/\v(pat|tern)/cmd'), 'cmd')
+  End
+  It picks nothing when pattern of :global hasn't finished yet
+    Assert Equals(PickTarget('g/\v(pat|tern'), '')
+  End
+  Context in :execute
+    It picks a command
+      Assert Equals(PickTarget('execute "cmd'), 'cmd')
+      Assert Equals(PickTarget("execute 'cmd"), 'cmd')
+    End
+    It picks nothing when inputting command's arguments
+      Assert Equals(PickTarget('execute "cmd args'), '')
+      Assert Equals(PickTarget("execute 'cmd args"), '')
+    End
+    It picks a command just after <bar>
+      Assert Equals(PickTarget('execute "another_cmd args|cmd'), 'cmd')
+      Assert Equals(PickTarget("execute 'another_cmd args|cmd"), 'cmd')
+    End
+    It supports string concatenation
+      Assert Equals(PickTarget('execute "some_cmd" "cmd'), 'cmd')
+      Assert Equals(PickTarget("execute 'some_cmd' 'cmd"), 'cmd')
+    End
+    It supports strings and variables in its arguments
+      Assert Equals(PickTarget('execute "string_arg" args'), '')
+      Assert Equals(PickTarget('execute args "string_arg"'), '')
+    End
+    It supports escaped quotes in arguments
+      Assert Equals(PickTarget('execute "string\"argument"|cmd'), 'cmd')
+      Assert Equals(PickTarget("execute 'string''argument'|cmd"), 'cmd')
+      Assert Equals(PickTarget("execute \"'<,'>cmd"), 'cmd')
+      Assert Equals(PickTarget("execute '''<,''>cmd"), 'cmd')
+    End
+  End
+  It can find the end of :execute
+    Assert Equals(PickTarget('execute "some_cmd"|cmd'), 'cmd')
+    Assert Equals(PickTarget("execute 'some_cmd'|cmd"), 'cmd')
+    Assert Equals(PickTarget("execute '%some_cmd'|cmd"), 'cmd')
+    Assert Equals(PickTarget("execute '''<,''>some_cmd'|cmd"), 'cmd')
+  End
+  It can find the end of :execute strings and variables as its arguments
+    Assert Equals(PickTarget('execute "string_arg" args|cmd'), 'cmd')
+    Assert Equals(PickTarget('execute args "string_arg"|cmd'), 'cmd')
+  End
+  It can find the end of :execute with variables as its arguments
+    Assert Equals(PickTarget('execute args|cmd'), 'cmd')
+    Assert Equals(PickTarget('execute args'), '')
+  End
+  It supports single quote in double-quoted string in :execute's arguments
+    Assert Equals(PickTarget('execute "string''arg"|cmd'), 'cmd')
+  End
+  It supports double quote in single-quoted string in :execute's arguments
+    Assert Equals(PickTarget("execute 'string\"arg'|cmd"), 'cmd')
+  End
+  It supports nested :execute
+    Assert Equals(PickTarget('execute "execute \"cmd'), 'cmd')
+    Assert Equals(PickTarget("execute 'execute ''cmd"), 'cmd')
+    Assert Equals(PickTarget('execute "execute \"some_cmd\""|cmd'), 'cmd')
+    Assert Equals(PickTarget("execute 'execute ''some_cmd'''|cmd"), 'cmd')
+  End
+  It picks the latest command
+    Assert Equals(PickTarget('before|cmd'), 'cmd')
+  End
+  It supports :global
+    Assert Equals(PickTarget('g/pat/before|cmd'), 'cmd')
+  End
+  It supports nested :global (Is it available in Vim?)
+    Assert Equals(PickTarget('g/pat/g/pat2/cmd'), 'cmd')
+    Assert Equals(PickTarget('g/pat/%g/pat2/cmd'), 'cmd')
+    Assert Equals(PickTarget('g/pat/before|g/pat2/cmd'), 'cmd')
+    Assert Equals(PickTarget('g/pat/before|%g/pat2/cmd'), 'cmd')
+  End
+  After all
+    delfunction PickTarget
+  End
+End
+Describe s:get_completion()
+  Before all
+    command! Hoge   echo 'Do nothing'
+    command! FooBar echo 'Do nothing'
+    command! FooBaz echo 'Do nothing'
+    command! FooFoo echo 'Do nothing'
+
+    function GetCompletion(target)
+      try
+        return s:functions.get_completion(a:target)
+      catch /^ambicmd\:\sCancelExpanding$/
+        return 0
+      endtry
+    endfunction
+  End
+  It expands an ambiguous command into a user-defined command
+    Assert Equals(GetCompletion('hoge'), ['Hoge', 1])
+    Assert Equals(GetCompletion('hog'), ['Hoge', 1])
+    Assert Equals(GetCompletion('ho'), ['Hoge', 1])
+  End
+  It doesn't expand a command if it is a built-in command
+    Assert Equals(GetCompletion('h'), 0)
+    Assert Equals(GetCompletion('f'), 0)
+    Assert Equals(GetCompletion('fo'), 0)
+  End
+  It emulates longest of 'wildmode' feature
+    Assert Equals(GetCompletion('foo'), ['Foo', 0])
+    Assert Equals(GetCompletion('foob'), ['FooBa', 0])
+  End
+  After all
+    delcommand Hoge
+    delcommand FooBar
+    delcommand FooBaz
+    delcommand FooFoo
+    delfunction GetCompletion
+  End
+End
 Describe ambicmd.vim
   Before all
     command! FooFoo put ='FooFoo'


### PR DESCRIPTION
すみません、あまりコードは原型をとどめていませんが...

- `:{another-command}|{command}`
- `:g/{pattern}/{command}`
- `:execute '{command}'`

これらの位置にあるコマンドの展開のサポートができたので、とりあえずPR送ってみました。