### PR TITLE
Add an option to show the completion menu

### DIFF
--- a/autoload/ambicmd.vim
+++ b/autoload/ambicmd.vim
@@ -9,6 +9,9 @@
 if !exists('g:ambicmd#build_rule')
   let g:ambicmd#build_rule = 'ambicmd#default_rule'
 endif
+if !exists('g:ambicmd#show_completion_menu')
+  let g:ambicmd#show_completion_menu = 0
+endif
 
 function! ambicmd#default_rule(cmd)
   return [
@@ -296,7 +299,13 @@ function! ambicmd#expand(keys) abort
   if is_fullmatch
     let suffix = a:keys
   elseif is_cmdline
-    let suffix = "\<C-d>"
+    if g:ambicmd#show_completion_menu && &wildmenu && &wildcharm != 0
+      let suffix = nr2char(&wildcharm)
+    else
+      let suffix = "\<C-d>"
+    endif
+  elseif is_cmdwin && g:ambicmd#show_completion_menu
+    let suffix = "\<C-x>\<C-v>"
   else
     let suffix = ''
   endif

--- a/doc/ambicmd.txt
+++ b/doc/ambicmd.txt
@@ -81,7 +81,8 @@ ambicmd#expand({key-sequence})			*ambicmd#expand()*
 	  spaces.)
 	- If the expanding succeeded, returns the command and {key-sequence}.
 	- If the candidates of the command starts by the same phrase, returns
-	  it and <C-d>.
+	  it and keys to list or show completion.  (See
+	  |g:ambicmd#show_completion_menu| for the details.)
 	- Otherwise returns {key-sequence}.
 	See also |ambicmd-setting-examples|.
 
@@ -96,6 +97,21 @@ g:ambicmd#build_rule				*g:ambicmd#build_rule*
 	user-defined commands.
 	See |ambicmd-expanding-rule| for the details.
 	The default value is "ambicmd#default_rule".
+
+g:ambicmd#show_completion_menu		*g:ambicmd#show_completion_menu*
+	|Number|.
+	If this value is non-zero:
+	- When you're in command-line with 'wildmenu' enabled, and
+	  'wildcharm' set, 'wildcharm' will be used to show the completion
+	  menu; otherwise, <C-d> will be used instead in the same way as when
+	  this value is zero.  (You have to set 'wildmode' and 'wildcharm'
+	  option to enable this option in command-line.)
+	- When you're in |cmdline-window|, <C-x><C-v> will be used to show the
+	  completion menu.
+	If this value is zero:
+	- When you're in command-line, <C-d> will be used to list completion.
+	- When you're in |cmdline-window|, nothing will be used.
+	The default value is 0.
 
 
 


### PR DESCRIPTION
展開時に複数コマンドがマッチし、それらからプレフィックスが見つかった場合、プレフィックスを補完するだけでなく自動でVim内蔵のコマンド補完も起動し得るようにしました。
これは結構副作用がありそうだと思ったので、オプションでこの機能の有効/無効を切り替えられるようにした上で、デフォルトでは無効にしてあります。
オプション名は`g:ambicmd#show_completion_menu`です。
（..オプション名がちょっとしっくりこない気もするので、良い名前があったら教えてください...）