### PR TITLE
fix: Treating buffer-local and global command as different candidates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ jobs:
           - windows-latest
 
         vim_version:
-          - v7.4
           - v8.0.0000
           - v8.1.0005
           - v9.0.0000

--- a/.travis.yml
+++ b/.travis.yml
@@ -97,17 +97,11 @@ anchors:
 jobs:
   include:
     - <<: *linux
-      env: VIM_VERSION=v7.4
-    - <<: *linux
       env: VIM_VERSION=v8.0.0000
     - <<: *linux
       env: VIM_VERSION=v8.1.0005
     - <<: *linux
       env: VIM_VERSION=latest
-    - <<: *osx
-      env:
-        - VIM_VERSION=v7.4.903
-        - VIM_URL=https://github.com/macvim-dev/macvim/releases/download/snapshot-79/MacVim-7.4.dmg
     - <<: *osx
       env:
         - VIM_VERSION=v8.0.0003
@@ -118,10 +112,6 @@ jobs:
         - VIM_URL=https://github.com/macvim-dev/macvim/releases/download/snapshot-148/MacVim.dmg
     - <<: *osx
       env: VIM_VERSION=latest
-    - <<: *windows
-      env: VIM_VERSION=v7.3
-    - <<: *windows
-      env: VIM_VERSION=v7.4
     - <<: *windows
       env: VIM_VERSION=v8.0.0003
     - <<: *windows

--- a/autoload/ambicmd.vim
+++ b/autoload/ambicmd.vim
@@ -70,8 +70,8 @@ function! s:get_cmd_list() abort
   redir => cmdlistredir
   silent! command
   redir END
-  return map(split(cmdlistredir, "\n")[1 :],
-  \   'matchstr(v:val, ''\u\w*'')')
+  return uniq(sort(map(split(cmdlistredir, "\n")[1 :],
+  \   'matchstr(v:val, ''\u\w*'')')))
 endfunction
 
 function! s:get_cmdline_info() abort

--- a/doc/ambicmd.txt
+++ b/doc/ambicmd.txt
@@ -59,7 +59,7 @@ nothing by default.  Please see |ambicmd-setting-examples|.
 
 
 Requirements:
-- Vim 7.3 or later
+- Vim 8.0 or later
 
 Latest version:
 https://github.com/thinca/vim-ambicmd

--- a/test/ambicmd.vimspec
+++ b/test/ambicmd.vimspec
@@ -187,6 +187,8 @@ Describe s:get_completion()
     command! FooBar echo 'Do nothing'
     command! FooBaz echo 'Do nothing'
     command! FooFoo echo 'Do nothing'
+    command! CmdBothGlobalLocal echo 'Do nothing'
+    command! -buffer CmdBothGlobalLocal echo 'Do nothing'
 
     function GetCompletion(target)
       try
@@ -210,7 +212,19 @@ Describe s:get_completion()
     Assert Equals(GetCompletion('foo'), ['Foo', 0])
     Assert Equals(GetCompletion('foob'), ['FooBa', 0])
   End
+  It does not treat buffer-local command and global command as different completion candidates.
+    Assert Equals(GetCompletion('cmdbothgloballocal'), ['CmdBothGlobalLocal', 1])
+  End
   After all
+    " The `-buffer` argument for :delcommand is introduced in Vim 8.2.3433 or
+    " Neovim 0.7.0.
+    if has('patch-8.2.3433') || has('nvim-0.7.0')
+      delcommand -buffer CmdBothGlobalLocal
+      delcommand CmdBothGlobalLocal
+    else
+      delcommand CmdBothGlobalLocal  " Delete the buffer-local command first,
+      delcommand CmdBothGlobalLocal  " and then delete the global one.
+    endif
     delcommand Piyo
     delcommand FooBar
     delcommand FooBaz


### PR DESCRIPTION
If both a global command and a buffer-local command are provided for the same name, ambicmd.vim treats each as an individual completion candidate and doesn't merge them into one.  Therefore in that case, ambicmd.vim wrongly attempts to show available command lists.  This PR fixes this problem.

This PR also dropped the support for Vim7.4 or earlier because they don't have `uniq()` built-in function, which is newly used in this patch.  I thought it's ok to drop support for them because they're so old now, but if you don't want that, please let me know.  I'll implement another fix to keep support for Vim7.4 or earlier.

### Reproduce steps

- Prepare this `vimrc.vim`

    ```vim
    set nocompatible

    " Please modify this path
    set runtimepath^=~/.cache/vim/pack/minpac/opt/vim-ambicmd/

    command! Piyo echo 'buffer-local'
    command! -buffer Piyo echo 'buffer-local'

    cnoremap <expr> <CR> ambicmd#expand('<CR>')
    ```

- Run Vim by `vim -u NONE -S vimrc.vim`
- Type `:piyo<CR>`

#### Expected behavior

The input string "piyo" is expanded into "Piyo", and immediately "Piyo" is executed and "buffer-local" message is displayed on echo area.

#### Actual behavior

The input string "piyo" is expanded into "Piyo", but the command is not executed immediately and available commands are listed by `<C-d>` instead.
<img width="133" alt="image" src="https://github.com/user-attachments/assets/39785f7d-5c6f-4587-a4d1-92b1efd5e989" />


### Environment

- Vim 9.1.1435
